### PR TITLE
Display for Errors, return error from WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+js-sys = "0.3"
+thiserror = "1"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ The [demo app source](/demo) has a complete example of using `blurhash-wasm`.
 ```js
 import * as blurhash from "blurhash-wasm";
 
-// Returned as Uint8Array | undefined
 // You can use this to construct canvas-compatible resources
-const pixels = blurhash.decode("LKO2?U%2Tw=w]~RBVZRi};RPxuwH", 40, 30);
+try {
+  const pixels = blurhash.decode("LKO2?U%2Tw=w]~RBVZRi};RPxuwH", 40, 30);
+} catch (error) {
+  console.log(error);
+}
 ```
 
 ### encode

--- a/demo/App.js
+++ b/demo/App.js
@@ -47,9 +47,8 @@ function CustomImage(props) {
   useEffect(
     () => {
       // Decode the hash into pixels
-      // Returned as Uint8Array | undefined
-      const pixels = blurhash.decode(hash, WIDTH, HEIGHT);
-      if (pixels) {
+      try {
+        const pixels = blurhash.decode(hash, WIDTH, HEIGHT);
         // Set the pixels to the canvas
         const asClamped = new Uint8ClampedArray(pixels);
         const imageData = new ImageData(asClamped, WIDTH, HEIGHT);
@@ -60,6 +59,8 @@ function CustomImage(props) {
           const ctx = canvasEl.getContext('2d');
           ctx.putImageData(imageData, 0, 0);
         }
+      } catch (error) {
+        console.error(error);
       }
     },
     [hash]
@@ -128,10 +129,12 @@ function Pitch() {
         <code>
           {`import * as blurhash from "blurhash-wasm";
 
-// Returned as Uint8Array | undefined
 // You can use this to construct canvas-compatible resources
-const pixels = blurhash.decode("LKO2?U%2Tw=w]~RBVZRi};RPxuwH", 40, 30);
-`}
+try {
+  const pixels = blurhash.decode("LKO2?U%2Tw=w]~RBVZRi};RPxuwH", 40, 30);
+} catch (error) {
+  console.log(error);
+}`}
         </code>
       </pre>
       <div className="vs3">

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ mod utils;
 use std::cmp::Ordering;
 use std::convert::TryFrom;
 use std::f64::consts::PI;
-use wasm_bindgen::prelude::*;
 use thiserror::*;
+use wasm_bindgen::prelude::*;
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
 // allocator.
@@ -36,8 +36,7 @@ pub enum EncodingError {
 /// Decode for WASM target. If an error occurs, the function will throw a `JsError`.
 #[wasm_bindgen(js_name = "decode")]
 pub fn wasm_decode(blur_hash: &str, width: usize, height: usize) -> Result<Vec<u8>, JsValue> {
-    decode(blur_hash, width, height)
-        .map_err(|err| js_sys::Error::new(&err.to_string()).into())
+    decode(blur_hash, width, height).map_err(|err| js_sys::Error::new(&err.to_string()).into())
 }
 
 pub fn decode(blur_hash: &str, width: usize, height: usize) -> Result<Vec<u8>, Error> {
@@ -110,7 +109,7 @@ pub fn decode(blur_hash: &str, width: usize, height: usize) -> Result<Vec<u8>, E
             let int_g = linear_to_srgb(g);
             let int_b = linear_to_srgb(b);
 
-            pixels[4 * x + 0 + y * bytes_per_row] = int_r as u8;
+            pixels[4 * x + y * bytes_per_row] = int_r as u8;
             pixels[4 * x + 1 + y * bytes_per_row] = int_g as u8;
             pixels[4 * x + 2 + y * bytes_per_row] = int_b as u8;
             pixels[4 * x + 3 + y * bytes_per_row] = 255 as u8;
@@ -135,13 +134,11 @@ fn decode_ac(value: usize, maximum_value: f64) -> [f64; 3] {
     let quant_r = f64::floor((value / (19 * 19)) as f64);
     let quant_g = f64::floor(((value / 19) as f64) % 19f64);
     let quant_b = (value as f64) % 19f64;
-
-    let rgb = [
+    [
         sign_pow((quant_r - 9f64) / 9f64, 2f64) * maximum_value,
         sign_pow((quant_g - 9f64) / 9f64, 2f64) * maximum_value,
         sign_pow((quant_b - 9f64) / 9f64, 2f64) * maximum_value,
-    ];
-    rgb
+    ]
 }
 
 fn sign_pow(value: f64, exp: f64) -> f64 {
@@ -158,19 +155,19 @@ fn get_sign(n: f64) -> f64 {
 
 fn linear_to_srgb(value: f64) -> usize {
     let v = f64::max(0f64, f64::min(1f64, value));
-    if v <= 0.0031308 {
-        return (v * 12.92 * 255f64 + 0.5) as usize;
+    if v <= 0.003_130_8 {
+        (v * 12.92 * 255f64 + 0.5) as usize
     } else {
-        return ((1.055 * f64::powf(v, 1f64 / 2.4) - 0.055) * 255f64 + 0.5) as usize;
+        ((1.055 * f64::powf(v, 1f64 / 2.4) - 0.055) * 255f64 + 0.5) as usize
     }
 }
 
 fn srgb_to_linear(value: usize) -> f64 {
     let v = (value as f64) / 255f64;
     if v <= 0.04045 {
-        return v / 12.92;
+        v / 12.92
     } else {
-        return ((v + 0.055) / 1.055).powf(2.4);
+        ((v + 0.055) / 1.055).powf(2.4)
     }
 }
 
@@ -237,7 +234,7 @@ pub fn encode(
 
     let maximum_value: f64;
 
-    if ac.len() > 0 {
+    if !ac.is_empty() {
         // I'm sure there's a better way to write this; following the Swift atm :)
         let actual_maximum_value = ac
             .clone()
@@ -266,7 +263,7 @@ pub fn encode(
 }
 
 fn multiply_basis_function<F>(
-    pixels: &Vec<u8>,
+    pixels: &[u8],
     width: usize,
     height: usize,
     bytes_per_row: usize,
@@ -286,10 +283,8 @@ where
             let basis = basis_function(x as f64, y as f64);
             r += basis
                 * srgb_to_linear(
-                    usize::try_from(
-                        pixels[bytes_per_pixel * x + pixel_offset + 0 + y * bytes_per_row],
-                    )
-                    .unwrap(),
+                    usize::try_from(pixels[bytes_per_pixel * x + pixel_offset + y * bytes_per_row])
+                        .unwrap(),
                 );
             g += basis
                 * srgb_to_linear(
@@ -362,10 +357,8 @@ fn decode_base83_string(string: &str) -> usize {
     let mut value: usize = 0;
 
     for character in string.chars() {
-        match ENCODE_CHARACTERS.iter().position(|&c| c == character) {
-            Some(digit) => value = value * 83 + digit,
-
-            None => (),
+        if let Some(digit) = ENCODE_CHARACTERS.iter().position(|&c| c == character) {
+            value = value * 83 + digit
         }
     }
     value


### PR DESCRIPTION
This PR adds `Display` and `Error` impls for the errors, and returns a `JsError` with the formatted string to WASM. I have updated the documentation and demo to reflect this, and also fixed the warnings Clippy gave me.