### PR TITLE
Reduce allocations during encoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,10 +219,10 @@ pub fn encode(
         }
     }
 
-    let mut hash = String::new();
+    let mut hash = String::with_capacity(1 + 1 + 4 + 2 * ac.len());
 
     let size_flag = ((cx - 1) + (cy - 1) * 9) as usize;
-    hash += &encode_base83_string(size_flag, 1);
+    hash.extend(encode_base83_string(size_flag, 1));
 
     let maximum_value: f64;
 
@@ -239,16 +239,16 @@ pub fn encode(
             usize::min(82, f64::floor(actual_maximum_value * 166f64 - 0.5) as usize),
         );
         maximum_value = ((quantised_maximum_value + 1) as f64) / 166f64;
-        hash += &encode_base83_string(quantised_maximum_value, 1);
+        hash.extend(encode_base83_string(quantised_maximum_value, 1));
     } else {
         maximum_value = 1f64;
-        hash += &encode_base83_string(0, 1);
+        hash.extend(encode_base83_string(0, 1));
     }
 
-    hash += &encode_base83_string(encode_dc(dc), 4);
+    hash.extend(encode_base83_string(encode_dc(dc), 4));
 
     for factor in ac {
-        hash += &encode_base83_string(encode_ac(factor, maximum_value), 2);
+        hash.extend(encode_base83_string(encode_ac(factor, maximum_value), 2));
     }
 
     Ok(hash)
@@ -335,11 +335,10 @@ fn decode_base83_string(string: &str) -> usize {
         .fold(0, |value, digit| value * 83 + digit)
 }
 
-fn encode_base83_string(value: usize, length: u32) -> String {
+fn encode_base83_string(value: usize, length: u32) -> impl Iterator<Item=char> {
     (1..=length)
-        .map(|i| (value / usize::pow(83, length - i)) % 83)
+        .map(move |i| (value / usize::pow(83, length - i)) % 83)
         .map(|digit| ENCODE_CHARACTERS[digit])
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ fn decode_base83_string(string: &str) -> usize {
 
 fn encode_base83_string(value: usize, length: u32) -> impl Iterator<Item=char> {
     (1..=length)
-        .map(move |i| (value / usize::pow(83, length - i)) % 83)
+        .map(move |i| (value / 83usize.pow(length - i)) % 83)
         .map(|digit| ENCODE_CHARACTERS[digit])
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,30 +307,15 @@ fn encode_dc(value: [f64; 3]) -> usize {
     ((rounded_r << 16) + (rounded_g << 8) + rounded_b) as usize
 }
 
-fn encode_ac(value: [f64; 3], maximum_value: f64) -> usize {
-    let quant_r = f64::floor(f64::max(
-        0f64,
-        f64::min(
-            18f64,
-            f64::floor(sign_pow(value[0] / maximum_value, 0.5) * 9f64 + 9.5),
-        ),
-    ));
-    let quant_g = f64::floor(f64::max(
-        0f64,
-        f64::min(
-            18f64,
-            f64::floor(sign_pow(value[1] / maximum_value, 0.5) * 9f64 + 9.5),
-        ),
-    ));
-    let quant_b = f64::floor(f64::max(
-        0f64,
-        f64::min(
-            18f64,
-            f64::floor(sign_pow(value[2] / maximum_value, 0.5) * 9f64 + 9.5),
-        ),
-    ));
+fn encode_ac([r, g, b]: [f64; 3], maximum_value: f64) -> usize {
+    let quant = |v| {
+        (sign_pow(v / maximum_value, 0.5) * 9. + 9.5)
+            .floor()
+            .min(18.)
+            .max(0.)
+    };
 
-    (quant_r * 19f64 * 19f64 + quant_g * 19f64 + quant_b) as usize
+    (quant(r) * 19f64 * 19f64 + quant(g) * 19f64 + quant(b)) as usize
 }
 
 // Base83

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ fn decode_base83_string(string: &str) -> usize {
         .fold(0, |value, digit| value * 83 + digit)
 }
 
-fn encode_base83_string(value: usize, length: u32) -> impl Iterator<Item=char> {
+fn encode_base83_string(value: usize, length: u32) -> impl Iterator<Item = char> {
     (1..=length)
         .map(move |i| (value / 83usize.pow(length - i)) % 83)
         .map(|digit| ENCODE_CHARACTERS[digit])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,11 +228,11 @@ pub fn encode(
 
     if !ac.is_empty() {
         // I'm sure there's a better way to write this; following the Swift atm :)
+        let maxf = |a: &f64, b: &f64|  a.partial_cmp(b).unwrap_or(Ordering::Equal);
         let actual_maximum_value = ac
-            .clone()
-            .into_iter()
-            .map(|[a, b, c]| f64::max(f64::max(f64::abs(a), f64::abs(b)), f64::abs(c)))
-            .max_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal))
+            .iter()
+            .map(|channels| channels.iter().copied().map(f64::abs).max_by(maxf).unwrap())
+            .max_by(maxf)
             .unwrap();
         let quantised_maximum_value = usize::max(
             0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,9 +203,9 @@ pub fn encode(
                 bytes_per_pixel,
                 0,
                 |a, b| {
-                    (normalisation
+                    normalisation
                         * f64::cos((PI * x as f64 * a) / width as f64)
-                        * f64::cos((PI * y as f64 * b) / height as f64))
+                        * f64::cos((PI * y as f64 * b) / height as f64)
                 },
             );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,11 +300,9 @@ where
     [r * scale, g * scale, b * scale]
 }
 
-fn encode_dc(value: [f64; 3]) -> usize {
-    let rounded_r = linear_to_srgb(value[0]);
-    let rounded_g = linear_to_srgb(value[1]);
-    let rounded_b = linear_to_srgb(value[2]);
-    ((rounded_r << 16) + (rounded_g << 8) + rounded_b) as usize
+fn encode_dc([r, g, b]: [f64; 3]) -> usize {
+    let rounded = |v| linear_to_srgb(v);
+    ((rounded(r) << 16) + (rounded(g) << 8) + rounded(b)) as usize
 }
 
 fn encode_ac([r, g, b]: [f64; 3], maximum_value: f64) -> usize {


### PR DESCRIPTION
I didn't know whether to expect #10 to be accepted, but since it was, here are some similar optimizations (with more detailed explanations).

# Summary

Using the iterator extend pattern can drastically reduce the number of allocations (as well as total memory allocated!) when generating the hash for image (in the `encode` function).

# Status Quo

Previously, `encode_base83_string` allocated a new `String` every time it was called. This incurred a heap allocation _at least_  3 times, despite the string only being between 1 and 4 characters long. Additionally, another heap allocation would be incurred for every encoded ac component.

# Optimizations

1. **Preallocating the `hash` string** so that it never has to be resized. Visually counting up the number of characters to be placed in the string yields this equation for the hash string size: `1 + 1 + 4 + 2(factors)`. Specifically, 1 for the size flag, 1 for quantized maximum value (or a zero), 4 for the dc component, and 2 times the number of factors (i.e. `2 * ac.len()`).
2. **Extending the string with a `char` iterator** rather than appending a `String`. Changing the return of the internal function `encode_base83_string` to the opaque type `impl Iterator<Item=char>` means that the characters of the hash string can be lazily generated without intermediate heap allocations for each `String`. The iterator is then consumed by the `String::extend` method, which takes into account the size hint of the iterator; since the size hint will be exact (check `RangeFull::size_hint` and `Map::size_hint`), this means that the method will always know the exact size to reserve during the extension. However, since we already preallocated, we will never have the reserve anything. This means that `extend` will simply be a safety size check (simply an integer comparison) and then a bunch of `push` calls (usually just 1 or 2 anyway).

# Implications and Benefits

All in all, we reduce the number of allocations from `O(n)` to `O(1)` (where `n` is the number of ac components). This is beneficial because the WASM memory model punishes frequent, small allocations. Additionally, using less memory when using `wee_alloc` is beneficial because `wee_alloc`'s allocation is an `O(n)` operation. Moreover, `wee_alloc` has a two-word overhead for each allocation, meaning we have a constant four words of overhead rather than an unbounded amount.